### PR TITLE
Replace unicode U+276F with plaintext character

### DIFF
--- a/tab-command/src/service/terminal/fuzzy.rs
+++ b/tab-command/src/service/terminal/fuzzy.rs
@@ -640,7 +640,7 @@ impl FuzzyFinderService {
         stdout.queue(Hide)?;
 
         stdout.queue(MoveTo(0, 0))?;
-        stdout.queue(Print("❯ "))?;
+        stdout.queue(Print("> "))?;
         stdout.queue(Print(query.query.as_str().bold()))?;
         stdout.queue(Clear(ClearType::UntilNewLine))?;
 
@@ -659,7 +659,7 @@ impl FuzzyFinderService {
             stdout.queue(MoveTo(0, row as u16))?;
 
             if selected {
-                stdout.queue(PrintStyledContent("❯ ".blue()))?;
+                stdout.queue(PrintStyledContent("> ".blue()))?;
                 Self::print_selected_tab(stdout, name)?;
 
                 if let Some(doc) = doc {


### PR DESCRIPTION
Some users might not have access to unicode characters such as U+276F which is used as an indicator during fuzzy searching. This could be replaced with a plain text alternative such as a larger than. For example this is an option provided by other projects including the starship prompt.

I've replaced replaced the hardcoded U+276F character with a plain text larger than. In the future, this could potentially be set by the user in a config.