### PR TITLE
Fix incorrect message about workspace errors

### DIFF
--- a/tab-command/src/service/main/list_tabs.rs
+++ b/tab-command/src/service/main/list_tabs.rs
@@ -30,7 +30,7 @@ impl Service for MainListTabsService {
                 if let MainRecv::ListTabs = msg {
                     let workspace = await_state(&mut rx_workspace).await?;
 
-                    if workspace.errors.is_empty() {
+                    if !workspace.errors.is_empty() {
                         eprintln!("Workspace errors were found during startup.  Use `tab --check` for more details.");
                         eprintln!();
                     }


### PR DESCRIPTION
There appears to have been a minor bug introduced in #366 which meant that when a user listed tabs using the CLI, a message was diplayed warning the user of errors, when no errors were present.

I've added a one liner change, just swapped out an is_empty() with an !is_empty(). This was all that was needed to resolve the issue.